### PR TITLE
implemented stack to solve max_depth_parentheses

### DIFF
--- a/Stack/max_depth_parentheses.py
+++ b/Stack/max_depth_parentheses.py
@@ -1,0 +1,60 @@
+'''
+Given a valid parentheses string s, return the nesting depth of s. The nesting depth is the maximum number of nested parentheses.
+
+ 
+
+Example 1:
+
+Input: s = "(1+(2*3)+((8)/4))+1"
+
+Output: 3
+
+Explanation:
+
+Digit 8 is inside of 3 nested parentheses in the string.
+
+Example 2:
+
+Input: s = "(1)+((2))+(((3)))"
+
+Output: 3
+
+Explanation:
+
+Digit 3 is inside of 3 nested parentheses in the string.
+
+Example 3:
+
+Input: s = "()(())((()()))"
+
+Output: 3
+
+ 
+
+Constraints:
+
+1 <= s.length <= 100
+s consists of digits 0-9 and characters '+', '-', '*', '/', '(', and ')'.
+It is guaranteed that parentheses expression s is a VPS.
+'''
+
+
+class Solution(object):
+    def maxDepth(self, s):
+        """
+        :type s: str
+        :rtype: int
+        """
+        stack = []
+
+        max_count = 0
+
+        for i in s:
+            if i == "(":
+                stack.append(i)
+            elif i == ")":
+                stack.pop()
+            if max_count < len(stack):
+                max_count = len(stack)
+        
+        return max_count


### PR DESCRIPTION
guaranteed that the expression is valid, so we do not need to worry about the case in which we pop an empy stack.

push if we see a front bracket pop if we see a back bracket.

For every iteration we check if the current length of the stack is greater than the max count, and replace the max count if it is.

Run time -> O(n)

Space time -> O(n)